### PR TITLE
Update 1.0.1: Use timestamp in vote_message, better readme, requirements.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+venv/
+.venv/
+vote_data.json

--- a/README.md
+++ b/README.md
@@ -1,56 +1,101 @@
-## How to Vote with Your Stake
+## How to Vote for Subnet Weights with Your Stake
 
 Before you proceed, please read the following important note:
 
+<br>
+
 ### ⚠️ **Important Warning:**
-**DO NOT RUN CODE ON YOUR MACHINE THAT YOU HAVE NOT AUDITED FIRST!** While the provided code is safe, it's essential to follow the adage: _"Verify, don’t trust."_ Always review any code before running it, especially on a machine that holds your wallet. The last thing we want is a repeat of the hack that occurred earlier this year.
+**DO NOT RUN CODE ON YOUR MACHINE THAT YOU HAVE NOT AUDITED FIRST!** While the provided code is safe, it's essential to follow the adage: _"Verify, don't trust."_ Always review any code before running it, especially on a machine that holds your wallet. The last thing we want is a repeat of the hack that occurred earlier this year.
 
 ---
-
+<br>
 
 ### Voting Options:
 
 #### 1. Vote via [app.minersunion.com](https://app.minersunion.com) (Easiest)
-- **Requirement:** Ensure your wallet is connected through the Chrome extension.
+- **Requirements:** Ensure your wallet is connected through the Chrome extension.
 
-#### 2. Vote via `sign_endpoint.py` (For Users with Wallets on `btcli`)
-- **Step-by-Step Instructions:**
-  1. Download and run the `sign_endpoint.py` script using the following command:
-     ```bash
-     curl -o sign.py https://raw.githubusercontent.com/minersunion/voting/main/sign.py && python3 sign.py
-     ```
-  2. Follow the on-screen instructions to cast your vote for the subnet weights
+#### 2. Vote via `Python` (For Users with Wallets on `btcli`)
+- **Requirements:** 
+  - Linux or WSL
+  - Python 3.10+
 
----
 
+<br>
+<br>
+
+# Method 1: Vote via web app
+
+User-friendly web app using your Bittensor compatible Chrome wallet extension.
+
+YouTube demo: https://youtu.be/_0fVJ4FeyJ8?si=f3O2Vc1pOjFL8Zia
+
+
+<br>
+<br>
+
+# Method 2: Vote via Python script
+
+### Setup and run:
+
+1. Clone the repository:
+    ```sh
+    git clone https://github.com/minersunion/voting.git
+    cd voting
+    ```
+
+2. Create a Python venv:
+    ```sh
+    sudo apt install python3-venv -y
+    python3 -m venv venv
+    source venv/bin/activate
+    ```
+
+3. Install dependencies:
+    ```sh
+    pip install -r requirements.txt
+   ```
+
+4. Run the python script:
+    ```sh
+    python sign.py
+    ```
+
+5. Follow instructions in your terminal
+
+<br>
 
 ### How it works:
 
+---
+
 #### 1. Signs a JSON string of text with your Bittensor wallet
 
-The raw JSON looks like this:
+The raw JSON now includes a timestamp and looks like this:
 ```json
-[
-  {"subnet": 1, "percent": 50.0},
-  {"subnet": 2, "percent": 50.0}
-]
-```
-
-When it is stringified to sign, it looks like this:
-`"[{\"subnet\": 1, \"percent\": 50.0}, {\"subnet\": 2, \"percent\": 50.0}]"`
-
-#### 2. Records the signed message in our database
-
-When the vote has been signed successfuly, we then save it securely in our database with a http POST request that looks like this:
-
-```python
-vote_data = {
-  "vote_message": "[{\"subnet\": 1, \"percent\": 50.0}, {\"subnet\": 2, \"percent\": 50.0}]", 
-  "signature": "", 
-  "hotkey_ss58": coldkey.ss58_address
+{
+  "timestamp": "2024-09-05T20:36:56.716393+00:00",
+  "weights": [
+    {"subnet": 1, "percent": 50.0},
+    {"subnet": 45, "percent": 50.0},
+  ]
 }
 ```
 
+When it is stringified to sign, it looks like this:
+`"{\"timestamp\": \"2024-09-05T20:36:56.716393+00:00\", \"weights\": [{\"subnet\": 1, \"percent\": 50.0}]}, {\"subnet\": 45, \"percent\": 50.0}]}"`
+
+#### 2. Records the signed message in our database
+
+When the vote has been signed successfully, we then save it securely in our database with an HTTP POST request that looks like this:
+
+```python
+vote_data = {
+  "vote_message": "{\"timestamp\": \"2024-09-05T20:36:56.716393+00:00\", \"weights\": [{\"subnet\": 28, \"percent\": 50.0}, {\"subnet\": 45, \"percent\": 50.0}]}", 
+  "signature": "faked85a263fdf7e410345a378baa8e694279b0c7069c89d6bfa9bd5ab42701defda054509540d38f2b71794faefff5483911ea554aad2878b61c2cf3fa01a80", 
+  "hotkey_ss58": "fakezayCxXifibJyUcFrfjzqpdH1pQdqQRiKFaw9v9vfake"
+}
+```
 
 ### Security Review
 
@@ -58,7 +103,7 @@ vote_data = {
 The script begins by loading a wallet that contains the private key (coldkey) necessary for signing the message. The wallet is identified by a user-specified name and path.
 
 #### 2. Generating the Vote Message
-The user inputs subnet IDs and associated percentages, which are compiled into a JSON structure representing the vote message. This message is then stringified to create a raw JSON string ready for signing.
+The user inputs subnet IDs and associated percentages, which are compiled into a JSON structure representing the vote message. This message now includes a timestamp and is then stringified to create a raw JSON string ready for signing.
 
 #### 3. Signing the Vote Message
 The script securely signs the JSON string of the vote message using the private key (coldkey) from the wallet. This signing process ensures that the message cannot be tampered with without detection, as the signature would no longer match.
@@ -70,6 +115,6 @@ To ensure the integrity of the signed message, the script verifies the signature
 The script packages the vote message, the signature, and the associated public key (in SS58 format) into a JSON object. This data is then securely transmitted to a server via an HTTPS POST request.
 
 #### 6. Optional Local Storage
-For record-keeping or backup purposes, the script optionally saves the signed data to a local file (`vote_data.json`). This step ensures that a copy of the signed message is available locally for reference or audit purposes.
+For record-keeping or backup purposes, the script saves the signed data to a local file (`vote_data.json`). This step ensures that a copy of the signed message is available locally for reference or audit purposes.
 
 This process securely signs a vote message, verifies its authenticity, and submits the signed message to a server, ensuring that the vote is both authenticated and securely recorded.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+bittensor
+substrateinterface
+requests

--- a/sign.py
+++ b/sign.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from datetime import datetime, timezone
 import requests
 from bittensor import wallet as btcli_wallet
 from substrateinterface import Keypair
@@ -56,7 +57,13 @@ if not subnets:
     print(f"{RED}No subnets entered. Exiting.{RESET}")
     exit(1)
 
-vote_message: str = json.dumps(subnets, indent=4)
+vote_message: str = json.dumps(
+    {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "weights": subnets,
+    },
+    indent=None,
+)
 print(f"{GREEN}Generated vote message:{RESET}")
 print(vote_message)
 


### PR DESCRIPTION
1. Use timestamp in the vote_message
2. Add a requirements.txt
3. Update the README using git clone instead of curl example